### PR TITLE
feat(gateway-version): use version 2

### DIFF
--- a/vapor.yml
+++ b/vapor.yml
@@ -23,6 +23,7 @@ environments:
             - "yarn prod && rm -rf node_modules"
     test:
         domain: test.mapmarker.io
+        gateway-version: 2
         memory: 1024
         cli-memory: 512
         runtime: docker


### PR DESCRIPTION
cheaper and should allow cloudflare caching