### PR TITLE
feat(icon-stack): add text rendering parameters

### DIFF
--- a/app/Http/Controllers/API/v3/FontAwesome/v6/IconStackController.php
+++ b/app/Http/Controllers/API/v3/FontAwesome/v6/IconStackController.php
@@ -34,6 +34,20 @@ class IconStackController extends Controller
         $backgroundIconColor = '#'.$request->get('oncolor', 'CCC');
         $backgroundIconMarkup = GetIconMarkup::run($backgroundIcon);
 
+        // TEXT
+        $text = htmlspecialchars((string) $request->get('text', ''), ENT_QUOTES | ENT_XML1, 'UTF-8');
+        $textColor = '#'.$request->get('text_color', 'FFF');
+        $textSize = $request->get('textsize', $markerSize / 3);
+        $textFont = 'Arial';
+        $textXOffsetPercent = 50 + ($request->get('text_hoffset', 0) / $markerSize * 100.00);
+        $textYOffsetPercent = 50 + ($request->get('text_voffset', 0) / $markerSize * 100.00);
+        $textMarkup = '';
+        if ($request->has('text')) {
+            $textMarkup = <<<EOD
+            <text x="{$textXOffsetPercent}%" y="{$textYOffsetPercent}%" fill="{$textColor}" text-anchor="middle" dy=".33em" font-size="{$textSize}" font-family="{$textFont}">{$text}</text>
+            EOD;
+        }
+
         // LABEL
         $labelMarkup = GetLabelMarkup::run(request: $request, markerSize: $markerSize);
 
@@ -46,6 +60,8 @@ class IconStackController extends Controller
             <svg fill="{$foregroundIconColor}" height="{$foregroundIconHeightPercent}%" x="{$foregroundIconXOffset}%" y="{$foregroundIconYOffset}%">
                 {$foregroundIconMarkup}
             </svg>
+
+            {$textMarkup}
 
             {$labelMarkup}
         </svg>

--- a/app/View/Components/MarkerCreator.php
+++ b/app/View/Components/MarkerCreator.php
@@ -67,6 +67,30 @@ class MarkerCreator extends Component
             'type' => 'number',
             'description' => 'You can manually adjust the position of the text vertically with this parmeter. Zero is the automatic center and you can move in positive or negative directions.',
         ],
+        'text_color' => [
+            'name' => 'Text Color',
+            'value' => 'FFF',
+            'type' => 'text',
+            'description' => 'The color of the text rendered on top of the icon stack.',
+        ],
+        'textsize' => [
+            'name' => 'Text Size',
+            'value' => 30,
+            'type' => 'number',
+            'description' => 'The font size of the text rendered on top of the icon stack.',
+        ],
+        'text_hoffset' => [
+            'name' => 'Text Horizontal Offset',
+            'value' => 0,
+            'type' => 'number',
+            'description' => 'Adjust the position of the text horizontally. Zero is centered on the marker and you can move in positive or negative directions.',
+        ],
+        'text_voffset' => [
+            'name' => 'Text Vertical Offset',
+            'value' => 0,
+            'type' => 'number',
+            'description' => 'Adjust the position of the text vertically. Zero is centered on the marker and you can move in positive or negative directions.',
+        ],
     ];
 
     public $parameters = [];

--- a/resources/views/docs/font-awesome/v6/icon-stacks.blade.php
+++ b/resources/views/docs/font-awesome/v6/icon-stacks.blade.php
@@ -24,6 +24,27 @@
                     ]" />
                 </x-docs-box>
             </div>
+            <div class="col-span-3">
+                <x-docs-box>
+                    <h2>Icon Stacks with Text</h2>
+                    <p>You can also render text on top of the icon stack to label markers (e.g. zone codes, counts, or identifiers).
+                        Combine two circles to create a border effect and position text in the center.
+                    </p>
+                    <x-marker-creator endpoint="/api/v3/font-awesome/v6/icon-stack" :fields="[
+                        'size',
+                        'icon' => ['value' => 'fa-solid fa-circle'],
+                        'iconsize' => ['value' => 65],
+                        'color' => ['value' => '28a745'],
+                        'on' => ['value' => 'fa-solid fa-circle'],
+                        'oncolor' => ['value' => 'FFFFFF'],
+                        'text' => ['value' => 'A1'],
+                        'text_color' => ['value' => 'FFF'],
+                        'textsize' => ['value' => 25],
+                        'text_hoffset' => ['value' => 0],
+                        'text_voffset' => ['value' => 0],
+                    ]" />
+                </x-docs-box>
+            </div>
         </div>
     </x-docs-layout>
 @endsection


### PR DESCRIPTION
## Summary
- Adds `text`, `text_color`, `textsize`, `text_hoffset`, `text_voffset` to the v3 font-awesome v6 `icon-stack` endpoint, rendering text centered on the marker by default with pixel-based offsets and a configurable color/size.
- Registers the new fields in the `MarkerCreator` component so they can be exposed in the interactive docs.
- Adds a second example to the icon-stacks docs page demonstrating the text feature (green circle on a white circle for a border effect, text "A1").

## Test plan
- [ ] Visit `/documentation/font-awesome/v6/icon-stacks` and confirm both examples render.
- [ ] Hit `/api/v3/font-awesome/v6/icon-stack?...&text=A1&text_color=FFF&textsize=25` and confirm the SVG contains a `<text>` element with the expected attributes.
- [ ] Hit the endpoint without `text` and confirm no text element is rendered (backwards compatible).
- [ ] Tweak `text_hoffset` / `text_voffset` and confirm the text shifts from center.
- [ ] Pass `<script>` in `text` and confirm output is HTML-escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)