### PR TITLE
ci: dispatch staging deploy after semantic-release publishes a tag

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - '**'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Tag or ref to deploy (defaults to the ref this workflow was dispatched on)
+        required: false
 
 concurrency:
   group: deploy-staging
@@ -16,6 +21,8 @@ jobs:
     environment: staging
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   tag-version:
@@ -33,7 +34,21 @@ jobs:
       - name: Install JS dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Capture current tag
+        id: pre
+        run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo none)" >> "$GITHUB_OUTPUT"
+
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: yarn release
+
+      - name: Detect new tag
+        id: post
+        run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo none)" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch staging deploy
+        if: steps.post.outputs.tag != steps.pre.outputs.tag && steps.post.outputs.tag != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy-staging.yml --ref "${{ steps.post.outputs.tag }}"

--- a/resources/views/docs/font-awesome/v4/icon-stacks.blade.php
+++ b/resources/views/docs/font-awesome/v4/icon-stacks.blade.php
@@ -9,7 +9,7 @@
             <div class="col-span-3">
                 <x-docs-box>
                     <h2>Icon Stacks</h2>
-                    <p>You can generate complex icons to convey importan attributes when rendering lots of data on a map.
+                    <p>You can generate complex icons to convey important attributes when rendering lots of data on a map.
                         This will help improve your users understanding of what is going on when lots of things are moving.
                     </p>
                     <x-marker-creator endpoint="/api/v1/font-awesome/v4/icon-stack" :fields="[

--- a/resources/views/docs/font-awesome/v5/icon-stacks.blade.php
+++ b/resources/views/docs/font-awesome/v5/icon-stacks.blade.php
@@ -9,7 +9,7 @@
             <div class="col-span-3">
                 <x-docs-box>
                     <h2>Icon Stacks</h2>
-                    <p>You can generate complex icons to convey importan attributes when rendering lots of data on a map.
+                    <p>You can generate complex icons to convey important attributes when rendering lots of data on a map.
                         This will help improve your users understanding of what is going on when lots of things are moving.
                     </p>
                     <x-marker-creator endpoint="/api/v2/font-awesome/v5/icon-stack" :fields="[

--- a/resources/views/docs/font-awesome/v6/icon-stacks.blade.php
+++ b/resources/views/docs/font-awesome/v6/icon-stacks.blade.php
@@ -9,7 +9,7 @@
             <div class="col-span-3">
                 <x-docs-box>
                     <h2>Icon Stacks</h2>
-                    <p>You can generate complex icons to convey importan attributes when rendering lots of data on a map.
+                    <p>You can generate complex icons to convey important attributes when rendering lots of data on a map.
                         This will help improve your users understanding of what is going on when lots of things are moving.
                     </p>
                     <x-marker-creator endpoint="/api/v3/font-awesome/v6/icon-stack" :fields="[


### PR DESCRIPTION
## Summary

Tag `1.65.0` was created by semantic-release on the previous merge to main, but `deploy-staging.yml` never fired. Root cause: semantic-release adds `[skip ci]` to its release commit (to stop the Release workflow re-triggering itself), and GitHub honors that marker for every event tied to the commit — including tag pushes. CircleCI's `[skip ci]` only suppressed commit pushes, not tag pushes, so this worked there.

This PR:
- Adds `workflow_dispatch` to `deploy-staging.yml` with an optional `ref` input, and checks out that ref so the dispatched run deploys the tagged code.
- In `release.yml`, captures the latest tag before/after running semantic-release. If a new tag was created, explicitly dispatches `deploy-staging.yml` against that tag via `gh workflow run`. `workflow_dispatch` is one of the few events `GITHUB_TOKEN` is allowed to trigger.
- Grants `actions: write` permission to the release job so it can dispatch.

## Catching up
After merging, the previously-pushed tag `1.65.0` won't auto-deploy (nothing runs retroactively). You can deploy it manually after merge with:

```
gh workflow run deploy-staging.yml --ref 1.65.0
```

## Test plan
- [ ] Merge this PR → release workflow runs → creates next tag → dispatches deploy-staging → deploy-staging runs against the new tag.
- [ ] Confirm the deploy-staging job's "Checkout" step shows the tag SHA, not main HEAD.
- [ ] Manually dispatch `deploy-staging.yml` with `ref=1.65.0` to backfill the staging deploy for the existing tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)