### PR TITLE
feat(docs): document animated labels for icons, icon stacks, and pins

### DIFF
--- a/resources/views/docs/font-awesome/v6/icon-stacks.blade.php
+++ b/resources/views/docs/font-awesome/v6/icon-stacks.blade.php
@@ -45,6 +45,112 @@
                     ]" />
                 </x-docs-box>
             </div>
+
+            <div class="col-span-3">
+                <x-docs-box>
+                    <h2>Icon Stacks with Labels</h2>
+                    <p>Just like icons and pins, icon stacks support labels &mdash; a small colored circle with text in
+                        the bottom-right corner of the marker. This is great for showing a count, status, or short code
+                        alongside a stacked marker. Add the <code>label</code> parameter with the text you want to show.
+                        Note that this is separate from the <code>text</code> parameter, which renders centered on top of
+                        the stack.</p>
+
+                    <div class="not-prose flex flex-wrap items-end gap-8 my-8">
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon-stack?size=100&icon=fa-solid%20fa-map-pin&iconsize=35&color=8F2BDB&on=fa-solid%20fa-map&oncolor=BC5AF4&label=3&lc=D9534F" alt="Icon stack with a red label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">label=3</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon-stack?size=100&icon=fa-solid%20fa-truck&iconsize=45&color=FFF&on=fa-solid%20fa-circle&oncolor=333&label=!&lc=F0AD4E&lfc=000" alt="Icon stack with an amber label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">lc=F0AD4E&amp;lfc=000</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon-stack?size=100&icon=fa-solid%20fa-warehouse&iconsize=40&color=FFF&on=fa-solid%20fa-circle&oncolor=28a745&label=12&lc=8F2BDB" alt="Icon stack with a purple label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">lc=8F2BDB</figcaption>
+                        </figure>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="w-1 text-lg pr-4">Parameter</th>
+                                <th class="w-1 text-lg">Example</th>
+                                <th class="text-lg">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="font-mono font-black pr-4">label</td>
+                                <td class="font-mono">3</td>
+                                <td>The text shown inside the label circle. Keep it short (1&ndash;3 characters) so it fits.</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lc</td>
+                                <td class="font-mono">D9534F</td>
+                                <td>The fill color of the label circle (hex, without the leading <code>#</code>).</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lfc</td>
+                                <td class="font-mono">FFF</td>
+                                <td>The color of the label text (hex, without the leading <code>#</code>).</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lf</td>
+                                <td class="font-mono">Arial</td>
+                                <td>The font family used for the label text.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </x-docs-box>
+            </div>
+
+            <div class="col-span-3">
+                <x-docs-box>
+                    <h2>Animated Labels</h2>
+                    <p>Animate the label to make an icon stack stand out on a busy map. Add the
+                        <code>labelAnimation</code> parameter with one of <code>blink</code>, <code>ping</code>, or
+                        <code>pulse</code>, and optionally tune the speed with <code>labelAnimationDuration</code>
+                        (e.g. <code>1s</code>). The animation is embedded directly in the SVG, so it plays automatically
+                        wherever the image is rendered.</p>
+
+                    <div class="not-prose flex flex-wrap items-end gap-8 my-8">
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon-stack?size=100&icon=fa-solid%20fa-truck&iconsize=45&color=FFF&on=fa-solid%20fa-circle&oncolor=333&label=3&lc=D9534F&labelAnimation=blink&labelAnimationDuration=1s" alt="Icon stack with a blinking label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=blink</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon-stack?size=100&icon=fa-solid%20fa-truck&iconsize=45&color=FFF&on=fa-solid%20fa-circle&oncolor=333&label=3&lc=D9534F&labelAnimation=ping&labelAnimationDuration=1s" alt="Icon stack with a pinging label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=ping</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon-stack?size=100&icon=fa-solid%20fa-truck&iconsize=45&color=FFF&on=fa-solid%20fa-circle&oncolor=333&label=3&lc=D9534F&labelAnimation=pulse&labelAnimationDuration=1s" alt="Icon stack with a pulsing label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=pulse</figcaption>
+                        </figure>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="w-1 text-lg pr-4">Parameter</th>
+                                <th class="w-1 text-lg">Example</th>
+                                <th class="text-lg">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="font-mono font-black pr-4">labelAnimation</td>
+                                <td class="font-mono">pulse</td>
+                                <td>The animation applied to the label. One of <code>blink</code>, <code>ping</code>, or <code>pulse</code>.</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">labelAnimationDuration</td>
+                                <td class="font-mono">1s</td>
+                                <td>How long one animation cycle takes, as a CSS duration (e.g. <code>1s</code>, <code>500ms</code>). Defaults to <code>1s</code>.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </x-docs-box>
+            </div>
         </div>
     </x-docs-layout>
 @endsection

--- a/resources/views/docs/font-awesome/v6/icons.blade.php
+++ b/resources/views/docs/font-awesome/v6/icons.blade.php
@@ -14,6 +14,111 @@
                     <x-marker-creator endpoint="/api/v3/font-awesome/v6/icon" :fields="['icon' => ['value' => 'fa-solid fa-star'], 'size', 'color' => ['value' => 'BC5AF4']]" />
                 </x-docs-box>
             </div>
+
+            <div class="col-span-3">
+                <x-docs-box>
+                    <h2>Icons with Labels</h2>
+                    <p>Add a label to any icon to draw attention to it or convey status at a glance. A label is a small
+                        colored circle with text placed in the bottom-right corner of the marker &mdash; perfect for
+                        counts, statuses, or short identifiers. Just add the <code>label</code> parameter with the text
+                        you want to show.</p>
+
+                    <div class="not-prose flex flex-wrap items-end gap-8 my-8">
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon?size=100&icon=fa-solid%20fa-person-hiking&color=333&label=5&lc=D9534F" alt="Icon with a red label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">label=5</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon?size=100&icon=fa-solid%20fa-triangle-exclamation&color=333&label=!&lc=F0AD4E&lfc=000" alt="Icon with an amber label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">lc=F0AD4E&amp;lfc=000</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon?size=100&icon=fa-solid%20fa-map-location&color=333&label=12&lc=28a745" alt="Icon with a green label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">lc=28a745</figcaption>
+                        </figure>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="w-1 text-lg pr-4">Parameter</th>
+                                <th class="w-1 text-lg">Example</th>
+                                <th class="text-lg">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="font-mono font-black pr-4">label</td>
+                                <td class="font-mono">5</td>
+                                <td>The text shown inside the label circle. Keep it short (1&ndash;3 characters) so it fits.</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lc</td>
+                                <td class="font-mono">D9534F</td>
+                                <td>The fill color of the label circle (hex, without the leading <code>#</code>).</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lfc</td>
+                                <td class="font-mono">FFF</td>
+                                <td>The color of the label text (hex, without the leading <code>#</code>).</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lf</td>
+                                <td class="font-mono">Arial</td>
+                                <td>The font family used for the label text.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </x-docs-box>
+            </div>
+
+            <div class="col-span-3">
+                <x-docs-box>
+                    <h2>Animated Labels</h2>
+                    <p>Make labels stand out on a busy map by animating them. Add the <code>labelAnimation</code>
+                        parameter with one of <code>blink</code>, <code>ping</code>, or <code>pulse</code>, and
+                        optionally tune the speed with <code>labelAnimationDuration</code> (e.g. <code>1s</code>).
+                        The animation is embedded directly in the SVG, so it plays automatically wherever the image is
+                        rendered.</p>
+
+                    <div class="not-prose flex flex-wrap items-end gap-8 my-8">
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon?size=100&icon=fa-solid%20fa-person-hiking&color=333&label=5&lc=D9534F&labelAnimation=blink&labelAnimationDuration=1s" alt="Icon with a blinking label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=blink</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon?size=100&icon=fa-solid%20fa-person-hiking&color=333&label=5&lc=D9534F&labelAnimation=ping&labelAnimationDuration=1s" alt="Icon with a pinging label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=ping</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/icon?size=100&icon=fa-solid%20fa-person-hiking&color=333&label=5&lc=D9534F&labelAnimation=pulse&labelAnimationDuration=1s" alt="Icon with a pulsing label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=pulse</figcaption>
+                        </figure>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="w-1 text-lg pr-4">Parameter</th>
+                                <th class="w-1 text-lg">Example</th>
+                                <th class="text-lg">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="font-mono font-black pr-4">labelAnimation</td>
+                                <td class="font-mono">pulse</td>
+                                <td>The animation applied to the label. One of <code>blink</code>, <code>ping</code>, or <code>pulse</code>.</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">labelAnimationDuration</td>
+                                <td class="font-mono">1s</td>
+                                <td>How long one animation cycle takes, as a CSS duration (e.g. <code>1s</code>, <code>500ms</code>). Defaults to <code>1s</code>.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </x-docs-box>
+            </div>
         </div>
     </x-docs-layout>
 @endsection

--- a/resources/views/docs/font-awesome/v6/pins.blade.php
+++ b/resources/views/docs/font-awesome/v6/pins.blade.php
@@ -31,6 +31,111 @@
                     ]" />
                 </x-docs-box>
             </div>
+
+            <div class="col-span-3">
+                <x-docs-box>
+                    <h2>Pins with Labels</h2>
+                    <p>Add a label to any pin to draw attention to it or convey status at a glance. A label is a small
+                        colored circle with text placed in the bottom-right corner of the marker &mdash; perfect for
+                        counts, statuses, or short identifiers. Just add the <code>label</code> parameter with the text
+                        you want to show. Labels work on both text pins and icon pins.</p>
+
+                    <div class="not-prose flex flex-wrap items-end gap-8 my-8">
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/pin?size=100&text=A&label=5&lc=D9534F" alt="Text pin with a red label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">label=5</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/pin?size=100&icon=fa-solid%20fa-star&color=FFF&label=!&lc=F0AD4E&lfc=000" alt="Icon pin with an amber label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">lc=F0AD4E&amp;lfc=000</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/pin?size=100&icon=fa-solid%20fa-location-dot&color=FFF&background=28a745&label=12&lc=8F2BDB" alt="Icon pin with a purple label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">lc=8F2BDB</figcaption>
+                        </figure>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="w-1 text-lg pr-4">Parameter</th>
+                                <th class="w-1 text-lg">Example</th>
+                                <th class="text-lg">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="font-mono font-black pr-4">label</td>
+                                <td class="font-mono">5</td>
+                                <td>The text shown inside the label circle. Keep it short (1&ndash;3 characters) so it fits.</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lc</td>
+                                <td class="font-mono">D9534F</td>
+                                <td>The fill color of the label circle (hex, without the leading <code>#</code>).</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lfc</td>
+                                <td class="font-mono">FFF</td>
+                                <td>The color of the label text (hex, without the leading <code>#</code>).</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">lf</td>
+                                <td class="font-mono">Arial</td>
+                                <td>The font family used for the label text.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </x-docs-box>
+            </div>
+
+            <div class="col-span-3">
+                <x-docs-box>
+                    <h2>Animated Labels</h2>
+                    <p>Make labels stand out on a busy map by animating them. Add the <code>labelAnimation</code>
+                        parameter with one of <code>blink</code>, <code>ping</code>, or <code>pulse</code>, and
+                        optionally tune the speed with <code>labelAnimationDuration</code> (e.g. <code>1s</code>).
+                        The animation is embedded directly in the SVG, so it plays automatically wherever the image is
+                        rendered.</p>
+
+                    <div class="not-prose flex flex-wrap items-end gap-8 my-8">
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/pin?size=100&icon=fa-solid%20fa-star&color=FFF&label=5&lc=D9534F&labelAnimation=blink&labelAnimationDuration=1s" alt="Pin with a blinking label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=blink</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/pin?size=100&icon=fa-solid%20fa-star&color=FFF&label=5&lc=D9534F&labelAnimation=ping&labelAnimationDuration=1s" alt="Pin with a pinging label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=ping</figcaption>
+                        </figure>
+                        <figure class="text-center">
+                            <img src="/api/v3/font-awesome/v6/pin?size=100&icon=fa-solid%20fa-star&color=FFF&label=5&lc=D9534F&labelAnimation=pulse&labelAnimationDuration=1s" alt="Pin with a pulsing label" class="mx-auto" />
+                            <figcaption class="mt-2 text-sm text-gray-400">labelAnimation=pulse</figcaption>
+                        </figure>
+                    </div>
+
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="w-1 text-lg pr-4">Parameter</th>
+                                <th class="w-1 text-lg">Example</th>
+                                <th class="text-lg">Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="font-mono font-black pr-4">labelAnimation</td>
+                                <td class="font-mono">pulse</td>
+                                <td>The animation applied to the label. One of <code>blink</code>, <code>ping</code>, or <code>pulse</code>.</td>
+                            </tr>
+                            <tr>
+                                <td class="font-mono font-black pr-4">labelAnimationDuration</td>
+                                <td class="font-mono">1s</td>
+                                <td>How long one animation cycle takes, as a CSS duration (e.g. <code>1s</code>, <code>500ms</code>). Defaults to <code>1s</code>.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </x-docs-box>
+            </div>
         </div>
     </x-docs-layout>
 @endsection


### PR DESCRIPTION
## Summary

The label feature — a colored circle with text and optional `blink`/`ping`/`pulse` animation — was already fully implemented in the API (the shared `GetLabelMarkup` action is wired into `IconController`, `IconStackController`, and `PinController`), but it was **undocumented**.

This PR adds written documentation sections with example images and parameter tables so users can discover and use the feature across all three v6 marker types.

## Changes

**`icons.blade.php`**
- **Icons with Labels** — documents `label`, `lc`, `lfc`, `lf` with three example markers.
- **Animated Labels** — documents `labelAnimation` (blink/ping/pulse) and `labelAnimationDuration`, with a live example of each.

**`icon-stacks.blade.php`**
- **Icon Stacks with Labels** — same parameters; clarifies the difference from the existing centered `text` parameter.
- **Animated Labels** — matching animation section.

**`pins.blade.php`**
- **Pins with Labels** — same parameters, covering both text pins and icon pins.
- **Animated Labels** — matching animation section.

All examples use real, working `/api/v3/font-awesome/v6/...` URLs.

## Testing
- All three doc pages render with HTTP 200 and contain the new sections.
- Verified the example image endpoints (`/icon`, `/icon-stack`, `/pin` with `label` + `labelAnimation`) return valid animated SVGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)